### PR TITLE
RFC: hide non-interactive Windows exec console windows

### DIFF
--- a/src-tauri/src/tools/exec.rs
+++ b/src-tauri/src/tools/exec.rs
@@ -247,6 +247,12 @@ async fn run_command(
         .env("PYTHONIOENCODING", "utf-8")
         .env("PYTHONLEGACYWINDOWSSTDIO", "0");
 
+    #[cfg(windows)]
+    if !tty {
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        command.as_std_mut().creation_flags(CREATE_NO_WINDOW);
+    }
+
     let child = command.spawn().map_err(|e| WorkspaceError::ToolDetails {
         code: "COMMAND_SPAWN_FAILED",
         message: format!("Failed to start command: {e}"),


### PR DESCRIPTION
## Problem

On Windows, commands launched through the generic `exec_command` / `run_command()` path can briefly open a visible console window when the packaged desktop app runs console programs such as `cmd.exe`, PowerShell, Python, or Node.

The desktop executable uses the Windows GUI subsystem, but that only affects the parent application. The current v0.1.23 / `main` implementation pipes stdin/stdout/stderr and then calls `command.spawn()` without child-process creation flags.

The dedicated Cloudflare and FRP launch paths already use `CREATE_NO_WINDOW`, so the generic execution path appears to be the remaining gap.

## Proposed change

Apply `CREATE_NO_WINDOW` only to non-interactive Windows executions (`tty == false`):

```rust
#[cfg(windows)]
if !tty {
    const CREATE_NO_WINDOW: u32 = 0x08000000;
    command.as_std_mut().creation_flags(CREATE_NO_WINDOW);
}
```

Restricting the flag to `tty == false` is intentional: interactive sessions may rely on normal console semantics, Ctrl events, or a real console host.

## Reproduction

From the packaged Windows desktop app, invoke the generic command tool repeatedly with commands such as:

```text
cmd /c echo test
powershell -NoProfile -Command "Write-Output test"
python -c "print('test')"
node -e "console.log('test')"
```

Observed behavior: a black console window may appear or flash briefly.

Expected behavior: non-interactive commands should remain hidden while stdin, stdout, stderr, exit codes, timeouts, and session handling continue to work normally.

## Validation status

- This branch is based on v0.1.23 / current `main` (`cad89d8c3d796017ee364747e78be8055f83b12b`).
- `git diff --check` passes.
- The local environment used to prepare this PR does not currently expose Cargo on `PATH`, so this exact v0.1.23 branch has not been compiled locally.
- An equivalent patch on a v0.1.22 candidate was previously built on GitHub `windows-latest`; existing Rust tests passed, and an isolated Windows regression covering CMD, PowerShell, Python, and Node reported `GetConsoleWindow() == 0` for each non-interactive child.

This PR is intentionally a draft/RFC so CI and maintainer review can determine whether:

1. `tty == false` is the correct boundary;
2. a configurable `show_console` / creation-mode option would be preferable; or
3. additional Windows session and Ctrl-event tests are required.

No command parsing, workspace policy, MCP/Actions lifecycle, ports, or configuration behavior is changed.
