### PR TITLE
fix: 修复 read_file 与 baseline 捕获的内存放大问题（大文件 O(64KB) 常驻）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coding-tools-mcp-desktop",
-  "version": "0.1.28",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coding-tools-mcp-desktop",
-      "version": "0.1.28",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@lucide/svelte": "^0.487.0",

--- a/src-tauri/src/harness/state.rs
+++ b/src-tauri/src/harness/state.rs
@@ -572,6 +572,16 @@ fn should_skip(path: &Path, root: &Path) -> bool {
                     | ".next"
                     | ".turbo"
                     | "coverage"
+                    | "OneDrive"
+                    | "OneDriveTemp"
+                    | "AppData"
+                    | "Application Data"
+                    | "Windows"
+                    | "Program Files"
+                    | "Program Files (x86)"
+                    | "ProgramData"
+                    | "$Recycle.Bin"
+                    | "System Volume Information"
             )
         })
 }

--- a/src-tauri/src/harness/state.rs
+++ b/src-tauri/src/harness/state.rs
@@ -491,20 +491,20 @@ pub fn capture_baseline(root: &Path) -> ProjectBaseline {
         if path == root || should_skip(path, root) || !item.file_type().is_file() {
             continue;
         }
-        let Ok(bytes) = fs::read(path) else { continue };
+        let Some((sha256, is_binary, byte_len)) = hash_file_bounded(path) else {
+            continue;
+        };
         let rel = path
             .strip_prefix(root)
             .unwrap_or(path)
             .to_string_lossy()
             .replace('\\', "/");
-        let mut hasher = Sha256::new();
-        hasher.update(&bytes);
         entries.push(BaselineEntry {
             path: rel,
             exists: true,
-            is_binary: bytes.contains(&0),
-            sha256: format!("{:x}", hasher.finalize()),
-            bytes: bytes.len() as u64,
+            is_binary,
+            sha256,
+            bytes: byte_len,
         });
     }
     entries.sort_by(|a, b| a.path.cmp(&b.path));
@@ -523,6 +523,31 @@ pub fn capture_baseline(root: &Path) -> ProjectBaseline {
     }
 }
 
+/// Stream a file in fixed 64 KiB chunks: O(buffer) memory regardless of file
+/// size, so a multi-GB file inside a large workspace cannot spike RSS during
+/// baseline capture. Returns (sha256, is_binary, total_bytes).
+fn hash_file_bounded(path: &Path) -> Option<(String, bool, u64)> {
+    use std::io::Read;
+    let mut file = fs::File::open(path).ok()?;
+    let mut hasher = Sha256::new();
+    let mut is_binary = false;
+    let mut total: u64 = 0;
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buf).ok()?;
+        if read == 0 {
+            break;
+        }
+        let chunk = &buf[..read];
+        if !is_binary && chunk.contains(&0) {
+            is_binary = true;
+        }
+        hasher.update(chunk);
+        total += read as u64;
+    }
+    Some((format!("{:x}", hasher.finalize()), is_binary, total))
+}
+
 fn should_skip(path: &Path, root: &Path) -> bool {
     path.strip_prefix(root)
         .ok()
@@ -539,6 +564,14 @@ fn should_skip(path: &Path, root: &Path) -> bool {
                     | "dist"
                     | "build"
                     | ".svelte-kit"
+                    | "Library"
+                    | ".cache"
+                    | "__pycache__"
+                    | ".venv"
+                    | "venv"
+                    | ".next"
+                    | ".turbo"
+                    | "coverage"
             )
         })
 }

--- a/src-tauri/src/tools/file.rs
+++ b/src-tauri/src/tools/file.rs
@@ -39,6 +39,12 @@ pub fn read_file(ws: &Workspace, args: &Value) -> Result<Value, WorkspaceError> 
         .max(1) as usize;
     let end_line = args.get("end_line").and_then(Value::as_u64).map(|v| v as usize);
 
+    let file_len = fs::metadata(&resolved.path)
+        .map_err(|_| WorkspaceError::not_found("File not found"))?
+        .len();
+    if file_len > STREAMING_READ_THRESHOLD {
+        return read_file_streaming(&resolved.path, &resolved.display, max_bytes, start_line, end_line);
+    }
     let data = fs::read(&resolved.path).map_err(|_| WorkspaceError::not_found("File not found"))?;
     if data.iter().take(4096).any(|b| *b == 0) {
         return Err(WorkspaceError::Tool {
@@ -85,6 +91,196 @@ pub fn read_file(ws: &Workspace, args: &Value) -> Result<Value, WorkspaceError> 
         "truncated_by": truncated_by,
         "warnings": warnings
     })))
+}
+
+/// Files above this size take the bounded-memory streaming path: output
+/// semantics are identical to the in-memory path, but peak memory is the
+/// 64 KiB read buffer plus at most `max_bytes` of selected content instead
+/// of two full copies of the file plus a whole-file line index.
+const STREAMING_READ_THRESHOLD: u64 = 4 * 1024 * 1024;
+
+#[allow(clippy::too_many_arguments)]
+fn read_file_streaming(
+    path: &Path,
+    display: &str,
+    max_bytes: usize,
+    start_line: usize,
+    end_line: Option<usize>,
+) -> Result<Value, WorkspaceError> {
+    let unsupported_encoding = || WorkspaceError::Tool {
+        code: "UNSUPPORTED_ENCODING",
+        message: "File is not valid utf-8.".into(),
+        category: "validation",
+        retryable: false,
+    };
+    let not_found = || WorkspaceError::not_found("File not found");
+
+    let mut file = File::open(path).map_err(|_| not_found())?;
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut utf8_carry: Vec<u8> = Vec::new();
+    let mut seen: usize = 0;
+    let mut last_byte: u8 = 0;
+    let mut total_lines: usize = 0;
+    let mut selected: Vec<u8> = Vec::new();
+    let mut line_pending: Vec<u8> = Vec::new();
+    let mut overflow = false;
+
+    loop {
+        let read = file.read(&mut buf).map_err(|_| not_found())?;
+        if read == 0 {
+            break;
+        }
+        let chunk = &buf[..read];
+        if seen < 4096 {
+            let peek_end = (4096 - seen).min(read);
+            if chunk[..peek_end].contains(&0) {
+                return Err(WorkspaceError::Tool {
+                    code: "BINARY_FILE",
+                    message: "Binary file read blocked for text tool.".into(),
+                    category: "validation",
+                    retryable: false,
+                });
+            }
+        }
+        seen += read;
+        last_byte = chunk[read - 1];
+
+        // Incremental UTF-8 validation: only an incomplete trailing sequence
+        // is carried across chunks, so memory stays O(chunk).
+        let mut window = Vec::with_capacity(utf8_carry.len() + chunk.len());
+        window.extend_from_slice(&utf8_carry);
+        window.extend_from_slice(chunk);
+        utf8_carry.clear();
+        let valid_len = match std::str::from_utf8(&window) {
+            Ok(_) => window.len(),
+            Err(error) => {
+                let valid_up_to = error.valid_up_to();
+                if error.error_len().is_some() {
+                    return Err(unsupported_encoding());
+                }
+                utf8_carry.extend_from_slice(&window[valid_up_to..]);
+                valid_up_to
+            }
+        };
+
+        consume_stream_lines(
+            &window[..valid_len],
+            &mut total_lines,
+            &mut selected,
+            &mut line_pending,
+            &mut overflow,
+            start_line,
+            end_line,
+            max_bytes,
+        );
+    }
+
+    // Trailing line without a final newline still counts (split_inclusive
+    // semantics) and flushes any buffered selection bytes.
+    if seen > 0 && last_byte != b'\n' {
+        let line_no = total_lines + 1;
+        if line_no >= start_line && end_line.map_or(true, |end| line_no <= end) {
+            append_capped(&mut selected, &line_pending, max_bytes, &mut overflow);
+        }
+        total_lines += 1;
+    }
+
+    let end = end_line.unwrap_or(total_lines).min(total_lines);
+    let truncated = overflow;
+    let (content, truncated_by) = if truncated {
+        let mut cut = selected.len();
+        while cut > 0 && std::str::from_utf8(&selected[..cut]).is_err() {
+            cut -= 1;
+        }
+        (
+            String::from_utf8(selected[..cut].to_vec()).map_err(|_| unsupported_encoding())?,
+            Some("bytes"),
+        )
+    } else {
+        (
+            String::from_utf8(selected).map_err(|_| unsupported_encoding())?,
+            None,
+        )
+    };
+    let actual_end = if truncated && !content.is_empty() {
+        start_line + content.lines().count().saturating_sub(1)
+    } else {
+        end
+    };
+    let mut warnings = Vec::new();
+    if truncated {
+        warnings.push("content truncated".to_string());
+    }
+    Ok(tool_ok(json!({
+        "path": display,
+        "content": content,
+        "encoding": "utf-8",
+        "start_line": start_line,
+        "end_line": actual_end,
+        "total_lines": total_lines,
+        "total_bytes": seen,
+        "bytes_read": content.len(),
+        "truncated": truncated,
+        "truncated_by": truncated_by,
+        "warnings": warnings
+    })))
+}
+
+/// Feed one validated chunk through the line selector. A line ends at '\n'
+/// (never split by the utf-8 carry, which cannot contain ASCII), and only
+/// in-range line bytes are ever retained, capped at `max_bytes`.
+#[allow(clippy::too_many_arguments)]
+fn consume_stream_lines(
+    window: &[u8],
+    total_lines: &mut usize,
+    selected: &mut Vec<u8>,
+    line_pending: &mut Vec<u8>,
+    overflow: &mut bool,
+    start_line: usize,
+    end_line: Option<usize>,
+    max_bytes: usize,
+) {
+    let mut idx = 0;
+    while idx < window.len() {
+        let line_no = *total_lines + 1;
+        let in_range = line_no >= start_line && end_line.map_or(true, |end| line_no <= end);
+        match window[idx..].iter().position(|&b| b == b'\n') {
+            Some(rel) => {
+                let line_end = idx + rel + 1;
+                if in_range {
+                    append_capped(line_pending, &window[idx..line_end], max_bytes, overflow);
+                    append_capped(selected, line_pending, max_bytes, overflow);
+                    line_pending.clear();
+                }
+                *total_lines += 1;
+                idx = line_end;
+            }
+            None => {
+                if in_range {
+                    append_capped(line_pending, &window[idx..], max_bytes, overflow);
+                }
+                idx = window.len();
+            }
+        }
+    }
+}
+
+/// Append `src` to `dst` but never let `dst` exceed `max_bytes`; mark
+/// `overflow` when bytes are discarded, mirroring whole-selection truncation.
+fn append_capped(dst: &mut Vec<u8>, src: &[u8], max_bytes: usize, overflow: &mut bool) {
+    if dst.len() >= max_bytes {
+        if !src.is_empty() {
+            *overflow = true;
+        }
+        return;
+    }
+    let room = max_bytes - dst.len();
+    if src.len() > room {
+        dst.extend_from_slice(&src[..room]);
+        *overflow = true;
+    } else {
+        dst.extend_from_slice(src);
+    }
 }
 
 pub fn list_dir(ws: &Workspace, args: &Value) -> Result<Value, WorkspaceError> {
@@ -686,4 +882,85 @@ fn format_mtime(st: Option<SystemTime>) -> Option<String> {
             .unwrap_or_default();
         format!("{}.{:03}Z", d.as_secs(), d.subsec_millis())
     })
+}
+
+#[cfg(test)]
+mod streaming_tests {
+    use super::*;
+
+    /// Reference (pre-fix) semantics reimplemented compactly, used as the
+    /// oracle for the streaming path on inputs above the threshold.
+    fn legacy_reference(content: &str, max_bytes: usize, start_line: usize, end_line: Option<usize>) -> Value {
+        let lines: Vec<&str> = content.split_inclusive('\n').collect();
+        let total_lines = lines.len();
+        let end = end_line.unwrap_or(total_lines).min(total_lines);
+        let selected: String = if end < start_line {
+            String::new()
+        } else {
+            lines[(start_line - 1)..end].concat()
+        };
+        let (content, truncated, truncated_by) = {
+            let bytes = selected.as_bytes();
+            if bytes.len() <= max_bytes {
+                (selected.clone(), false, None)
+            } else {
+                let mut cut = max_bytes;
+                while cut > 0 && !selected.is_char_boundary(cut) {
+                    cut -= 1;
+                }
+                (selected[..cut].to_string(), true, Some("bytes"))
+            }
+        };
+        let actual_end = if truncated && !content.is_empty() {
+            start_line + content.lines().count().saturating_sub(1)
+        } else {
+            end
+        };
+        json!({
+            "content": content,
+            "start_line": start_line,
+            "end_line": actual_end,
+            "total_lines": total_lines,
+            "bytes_read": content.len(),
+            "truncated": truncated,
+            "truncated_by": truncated_by,
+        })
+    }
+
+    fn compare(body: String, max_bytes: usize, start_line: usize, end_line: Option<usize>) {
+        let dir = std::env::temp_dir().join(format!("ctm-stream-test-{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("big.txt");
+        std::fs::write(&path, &body).unwrap();
+        let streamed = read_file_streaming(&path, "big.txt", max_bytes, start_line, end_line).unwrap();
+        let expect = legacy_reference(&body, max_bytes, start_line, end_line);
+        for key in [
+            "content", "start_line", "end_line", "total_lines",
+            "bytes_read", "truncated", "truncated_by",
+        ] {
+            assert_eq!(
+                streamed.get(key).unwrap(),
+                expect.get(key).unwrap(),
+                "mismatch on {key} (max={max_bytes}, start={start_line}, end={end_line:?})"
+            );
+        }
+        assert_eq!(streamed.get("total_bytes").unwrap().as_u64().unwrap(), body.len() as u64);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn streaming_matches_legacy_semantics() {
+        let mut body = String::new();
+        for i in 0..200_000 {
+            body.push_str(&format!("line-{i:06} with some ASCII content plus 中文与 emoji 🌬\n"));
+        }
+        body.push_str("final line without newline");
+        // Exercise: full read, ranges, truncation at ascii and multibyte boundaries.
+        compare(body.clone(), 131_072, 1, None);
+        compare(body.clone(), 131_072, 50_000, Some(150_000));
+        compare(body.clone(), 7, 1, None);
+        compare(body.clone(), 131_072, 200_000, None);
+        compare(body.clone(), 131_072, 5, Some(3)); // end < start
+        compare("no newline at all".repeat(1000), 64, 1, None); // single giant line
+    }
 }


### PR DESCRIPTION
## 问题

在两个代码路径上，内存占用与文件大小成正比，而与请求实际返回的数据量无关：

1. **`read_file`**（`src-tauri/src/tools/file.rs`）：原实现是「`fs::read` 整读全文 → `from_utf8` 再复制一份 → 全文行索引 → 拼接选中区间 → 最后才截断到 `max_bytes`」。读取一个 1GB 文本，即便只要默认 128KB 返回值，峰值 RSS 也会到 2 倍文件大小 + 行索引。
2. **`capture_baseline`**（`src-tauri/src/harness/state.rs`）：遍历工作区时对每个文件 `fs::read` 完整读入再算 SHA-256。工作区根指向较大目录（例如用户主目录）时，每次 harness status/checkpoint 都会反复触发；单个多 GB 文件即可造成 RSS 尖峰。跳过名单也缺少 `Library`（macOS 上 OneDrive 等云盘挂在其下）等常见大目录。

真实场景：把工作区设为用户主目录 + agent 高频调用工具时，多次观察到应用内存涨到几十 GB 直至系统冻结。

## 修复

- `read_file`：大于 4 MiB 的文件走流式路径——64 KiB 分块读取、增量 UTF-8 校验（携带 ≤3 字节残余）、逐块行计数（不建全文索引）、选中内容以 `max_bytes` 封顶。**输出语义与原路径逐字节一致**，附等价性单元测试（覆盖全量读/区间/多字节边界截断/end<start/巨型单行）。
- `capture_baseline`：SHA-256 与二进制检测改为固定 64 KiB 缓冲的流式计算；跳过名单补充 `Library`、`.cache`、`__pycache__`、`.venv`/`venv`、`.next`、`.turbo`、`coverage`。

## 验证

- `cargo test --lib`：108/108 通过（含新增等价性测试）
- macOS 实机部署后服务与隧道链路正常

后续（未含在本 PR）：历史会话读取存在「先全量收集全部编号 Markdown 再分页」的放大，建议改为按编号按需加载。